### PR TITLE
Save model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # Preprocessing Component
+
+## Install dependencies
+When running within a docker container, install python dependencies with:
+```
+pip install -r requirements.txt
+```

--- a/preprocess-train.py
+++ b/preprocess-train.py
@@ -6,6 +6,7 @@
 #
 
 # Importing libraries
+import dill
 import pandas as pd
 import numpy as np
 # scikit learn
@@ -54,3 +55,5 @@ svm_classifier = SVC(kernel='linear')
 svm_classifier.fit(X_train, y_train)  
 y_pred = svm_classifier.predict(X_test)  
 
+with open('model.pk', 'wb') as f:
+    dill.dump(svm_classifier, f)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+dill
+pandas
+numpy
+sklearn


### PR DESCRIPTION
Python's `dill` module extends the pickling library, and works to serialize and deserialize data in python-- especially useful for us as we want to convert models into a format that can be moved to the prediction server. 

At the end of training, we dump the model to a file called model.pk:
https://github.com/mecheverria96/archMLP-Preprocessing/blob/439000a8bca5d59d9230095eeba23e8709137b59/preprocess-train.py#L58-L59

After training the model and saving it to the `model.pk`, we can do other processing steps to get it ready for the prediction server. 